### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: lydia-portfolio-workflow
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: lydia-portfolio-workflow
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+
+      - name: setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: Echo environment variables to .env
+        run: |
+          echo "VITE_APP_EMAILJS_SERVICE_ID=${{ secrets.VITE_APP_EMAILJS_SERVICE_ID }}" >> .env
+          echo "VITE_APP_EMAILJS_TEMPLATE_ID=${{ secrets.VITE_APP_EMAILJS_TEMPLATE_ID }}" >> .env
+          echo "VITE_APP_EMAILJS_PUBLIC_KEY=${{ secrets.VITE_APP_EMAILJS_PUBLIC_KEY }}" >> .env
+
+      - name: Build the VITE app
+        run: npm run build
+
+      - name: Create 404.html for SPA routing
+        run: cp dist/index.html dist/404.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploying to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Summary
This Pull Request implements the deployment workflow described in Issue #<issue-number>.  
It introduces a GitHub Actions pipeline that automatically builds and deploys the portfolio to GitHub Pages on every push to `main`.

### What this PR includes
- Added `.github/workflows/deploy.yml`
- Configured build steps using Node 22 and Vite
- Added .env variable injection (based on repo secrets)
- Ensured SPA compatibility by generating `404.html`
- Deployed using `actions/deploy-pages@v4`

### Why this is beneficial
- Fully automated deployments
- No manual build steps required
- Reduces risk of inconsistent builds
- Aligns with industry CI/CD best practices

### Testing
- Verified workflow syntax
- Workflow triggers correctly on push and manual dispatch

### Related Issue
Closes #1 